### PR TITLE
Restify probe: Attach HTTP response status

### DIFF
--- a/lib/mnemosyne/probes/restify/base.rb
+++ b/lib/mnemosyne/probes/restify/base.rb
@@ -23,9 +23,10 @@ module Mnemosyne
                 request.headers['X-Mnemosyne-Origin'] = span.uuid
 
                 super.tap do |x|
-                  x.add_observer do |_, _response, _err|
-                    span.finish!
-                    trace << span
+                  x.add_observer do |_, response, _err|
+                    span.meta[:status] = response.code
+
+                    trace << span.finish!
                   end
                 end
               else

--- a/spec/mnemosyne/probes/restify/base_spec.rb
+++ b/spec/mnemosyne/probes/restify/base_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Mnemosyne::Probes::Restify::Base do
       expect(span.name).to eq 'external.http.restify'
       expect(span.meta[:url]).to eq 'http://google.com'
       expect(span.meta[:method]).to eq :get
+      expect(span.meta[:status]).to eq 200
     end
 
     it 'does not affect untraced requests' do

--- a/spec/mnemosyne/probes/restify/base_spec.rb
+++ b/spec/mnemosyne/probes/restify/base_spec.rb
@@ -25,5 +25,9 @@ RSpec.describe Mnemosyne::Probes::Restify::Base do
       expect(span.meta[:url]).to eq 'http://google.com'
       expect(span.meta[:method]).to eq :get
     end
+
+    it 'does not affect untraced requests' do
+      expect(request).to be
+    end
   end
 end

--- a/spec/mnemosyne/probes/restify/base_spec.rb
+++ b/spec/mnemosyne/probes/restify/base_spec.rb
@@ -4,20 +4,26 @@ require 'spec_helper'
 require 'webmock/rspec'
 
 RSpec.describe Mnemosyne::Probes::Restify::Base do
-  it 'creates span' do
-    trace = with_trace do
-      stub_request(:any, 'google.com')
+  before { require 'restify' }
 
-      require 'restify'
-      Restify.new('http://google.com').get.value!
+  describe 'a GET request' do
+    subject(:request) { Restify.new('http://google.com').get.value! }
+
+    before do
+      stub_request(:get, 'google.com')
+        .to_return(status: 200, body: 'search')
     end
 
-    expect(trace.span.size).to eq 1
+    it 'creates a span when tracing' do
+      trace = with_trace { request }
 
-    span = trace.span.first
+      expect(trace.span.size).to eq 1
 
-    expect(span.name).to eq 'external.http.restify'
-    expect(span.meta[:url]).to eq 'http://google.com'
-    expect(span.meta[:method]).to eq :get
+      span = trace.span.first
+
+      expect(span.name).to eq 'external.http.restify'
+      expect(span.meta[:url]).to eq 'http://google.com'
+      expect(span.meta[:method]).to eq :get
+    end
   end
 end


### PR DESCRIPTION
Analogous to how we do it for Faraday requests.

This allows for comparing the received status code with that generated by the backend service (which can be accessed easily in mnemosyne-server).
(The two can be different e.g. when an intermediate times out requests if the take too long.)

Fixes #12.