### PR TITLE
New probe for Redis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
           - rails-5.1
           - rails-5.2
           - rails-6.0
+          - redis-4.0
           - restify
           - sidekiq-5
           - sidekiq-6
@@ -50,6 +51,9 @@ jobs:
           - suite: rails-6.0
             spec: --tag probe:rails --tag ~probe
             env: BUNDLE_GEMFILE=gemfiles/rails_60.gemfile
+          - suite: redis-4.0
+            spec: --tag probe:redis
+            env: REDIS_VERSION='~> 4.0'
           - suite: restify
             spec: --tag probe:restify
           - suite: sidekiq-5
@@ -78,9 +82,10 @@ jobs:
           path: vendor
           key: v1-ruby-${{ matrix.ruby }}-suite-${{ matrix.suite }}
 
-      - name: Install Ruby dependencies
+      - name: Install dependencies
         run: |
           set -x
+          sudo apt install -y redis-server
           gem install bundler --version '1.17.3'
           bundle config path "$(pwd)/vendor/bundle"
           bundle config without development

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'timecop', '~> 0.9.1'
 group :test do
   gem 'faraday', ENV['FARADAY_VERSION'], require: false
   gem 'msgr',    ENV['MSGR_VERSION'],    require: false
+  gem 'redis',   ENV['REDIS_VERSION'],   require: false
   gem 'restify', ENV['RESTIFY_VERSION'], require: false
   gem 'sidekiq', ENV['SIDEKIQ_VERSION'], require: false
 

--- a/gemfiles/rails_50.gemfile
+++ b/gemfiles/rails_50.gemfile
@@ -10,6 +10,7 @@ gem "timecop", "~> 0.9.1"
 group :test do
   gem "faraday", nil, require: false
   gem "msgr", nil, require: false
+  gem "redis", nil, require: false
   gem "restify", nil, require: false
   gem "sidekiq", nil, require: false
   gem "rails", "~> 5.0.0", require: false

--- a/gemfiles/rails_51.gemfile
+++ b/gemfiles/rails_51.gemfile
@@ -10,6 +10,7 @@ gem "timecop", "~> 0.9.1"
 group :test do
   gem "faraday", nil, require: false
   gem "msgr", nil, require: false
+  gem "redis", nil, require: false
   gem "restify", nil, require: false
   gem "sidekiq", nil, require: false
   gem "rails", "~> 5.1.0", require: false

--- a/gemfiles/rails_52.gemfile
+++ b/gemfiles/rails_52.gemfile
@@ -10,6 +10,7 @@ gem "timecop", "~> 0.9.1"
 group :test do
   gem "faraday", nil, require: false
   gem "msgr", nil, require: false
+  gem "redis", nil, require: false
   gem "restify", nil, require: false
   gem "sidekiq", nil, require: false
   gem "rails", "~> 5.2.0", require: false

--- a/gemfiles/rails_60.gemfile
+++ b/gemfiles/rails_60.gemfile
@@ -10,6 +10,7 @@ gem "timecop", "~> 0.9.1"
 group :test do
   gem "faraday", nil, require: false
   gem "msgr", nil, require: false
+  gem "redis", nil, require: false
   gem "restify", nil, require: false
   gem "sidekiq", nil, require: false
   gem "rails", "~> 6.0.0", require: false

--- a/lib/mnemosyne.rb
+++ b/lib/mnemosyne.rb
@@ -42,6 +42,7 @@ module Mnemosyne
     require 'mnemosyne/probes/grape/endpoint_run_filters'
     require 'mnemosyne/probes/msgr/client'
     require 'mnemosyne/probes/msgr/consumer'
+    require 'mnemosyne/probes/redis/command'
     require 'mnemosyne/probes/responder/respond'
     require 'mnemosyne/probes/restify/base'
     require 'mnemosyne/probes/sidekiq/client'

--- a/lib/mnemosyne/probes/redis/command.rb
+++ b/lib/mnemosyne/probes/redis/command.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Mnemosyne
+  module Probes
+    module Redis
+      module Command
+        class Probe < ::Mnemosyne::Probe
+          def setup
+            ::Redis::Client.prepend ClientPatch
+          end
+
+          module ClientPatch
+            def process(commands)
+              trace = ::Mnemosyne::Instrumenter.current_trace
+              return super unless trace
+
+              span = ::Mnemosyne::Span.new 'db.query.redis',
+                meta: extract_span_meta(commands)
+
+              span.start!
+
+              super.tap do |retval|
+                span.meta[:error] = retval.message if retval.is_a?(::Redis::CommandError)
+
+                trace << span.finish!
+              end
+            end
+
+            private
+
+            def extract_span_meta(commands)
+              {
+                # Each command is an array, consisting of the command name and any
+                # arguments. We are only interested in the command name.
+                commands: extract_command_names(commands),
+
+                # If there are multiple commands, that must mean they were pipelined
+                # (i.e. run in parallel).
+                pipelined: commands.length > 1
+              }
+            end
+
+            def extract_command_names(commands)
+              commands.map do |c|
+                # Depending on how the methods on the Redis gem are called,
+                # there may be an additional level of nesting.
+                c = c[0] if c[0].is_a?(Array)
+
+                # Symbols and lower-case names are allowed
+                c[0].to_s.upcase
+              end.join(', ')
+            end
+          end
+        end
+      end
+    end
+
+    register 'Redis::Client',
+      'redis',
+      Redis::Command::Probe.new
+  end
+end

--- a/lib/mnemosyne/probes/redis/command.rb
+++ b/lib/mnemosyne/probes/redis/command.rb
@@ -30,6 +30,8 @@ module Mnemosyne
 
             def extract_span_meta(commands)
               {
+                server: id,
+
                 # Each command is an array, consisting of the command name and any
                 # arguments. We are only interested in the command name.
                 commands: extract_command_names(commands),

--- a/lib/mnemosyne/probes/redis/command.rb
+++ b/lib/mnemosyne/probes/redis/command.rb
@@ -48,9 +48,35 @@ module Mnemosyne
                 # there may be an additional level of nesting.
                 c = c[0] if c[0].is_a?(Array)
 
-                # Symbols and lower-case names are allowed
-                c[0].to_s.upcase
-              end.join(', ')
+                # For some commands, we also extract *some* of the arguments.
+                name, args = parse_name_and_args(c)
+
+                "#{name} #{args}".strip
+              end.join("\n")
+            end
+
+            ##
+            # A map of known commands to the arguments (identified by position)
+            # that should be included verbatim in the metadata. Arguments not
+            # listed here will be replaced by a "?" character.
+            #
+            KNOWN_ARGUMENTS = {
+              'GET' => [0],
+              'SET' => [0]
+            }.freeze
+
+            def parse_name_and_args(command)
+              command = command.dup
+
+              # Symbols and lower-case names are allowed
+              name = command.delete_at(0).to_s.upcase
+
+              allowed = KNOWN_ARGUMENTS[name] || []
+              args = command.each_with_index.map do |arg, index|
+                allowed.include?(index) ? arg : '?'
+              end.join(' ')
+
+              [name, args]
             end
           end
         end

--- a/spec/mnemosyne/probes/redis/command_spec.rb
+++ b/spec/mnemosyne/probes/redis/command_spec.rb
@@ -27,10 +27,12 @@ RSpec.describe ::Mnemosyne::Probes::Redis::Command, probe: :redis do
     span = trace.span[0]
     expect(span.name).to eq 'db.query.redis'
     expect(span.meta[:commands]).to eq 'SET'
+    expect(span.meta[:server]).to eq 'redis://127.0.0.1:16379/0'
 
     span = trace.span[1]
     expect(span.name).to eq 'db.query.redis'
     expect(span.meta[:commands]).to eq 'GET'
+    expect(span.meta[:server]).to eq 'redis://127.0.0.1:16379/0'
   end
 
   it 'creates just one span for pipelined (parallel) commands' do
@@ -49,6 +51,7 @@ RSpec.describe ::Mnemosyne::Probes::Redis::Command, probe: :redis do
     expect(span.name).to eq 'db.query.redis'
     expect(span.meta[:commands]).to eq 'SET, SET'
     expect(span.meta[:pipelined]).to eq true
+    expect(span.meta[:server]).to eq 'redis://127.0.0.1:16379/0'
   end
 
   it 'traces queued commands (also run in parallel when committing)' do
@@ -66,6 +69,7 @@ RSpec.describe ::Mnemosyne::Probes::Redis::Command, probe: :redis do
     expect(span.name).to eq 'db.query.redis'
     expect(span.meta[:commands]).to eq 'SET, SET'
     expect(span.meta[:pipelined]).to eq true
+    expect(span.meta[:server]).to eq 'redis://127.0.0.1:16379/0'
   end
 
   it 'traces commands queued with array syntax' do
@@ -83,6 +87,7 @@ RSpec.describe ::Mnemosyne::Probes::Redis::Command, probe: :redis do
     expect(span.name).to eq 'db.query.redis'
     expect(span.meta[:commands]).to eq 'SET, SET'
     expect(span.meta[:pipelined]).to eq true
+    expect(span.meta[:server]).to eq 'redis://127.0.0.1:16379/0'
   end
 
   it 'attaches errors to the span' do
@@ -98,5 +103,6 @@ RSpec.describe ::Mnemosyne::Probes::Redis::Command, probe: :redis do
     expect(span.name).to eq 'db.query.redis'
     expect(span.meta[:commands]).to eq 'UNKNOWN_FUNCTION'
     expect(span.meta[:error]).to start_with 'ERR unknown command'
+    expect(span.meta[:server]).to eq 'redis://127.0.0.1:16379/0'
   end
 end

--- a/spec/mnemosyne/probes/redis/command_spec.rb
+++ b/spec/mnemosyne/probes/redis/command_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe ::Mnemosyne::Probes::Redis::Command, probe: :redis do
 
     span = trace.span[0]
     expect(span.name).to eq 'db.query.redis'
-    expect(span.meta[:commands]).to eq 'SET'
+    expect(span.meta[:commands]).to eq 'SET mykey ?'
     expect(span.meta[:server]).to eq 'redis://127.0.0.1:16379/0'
 
     span = trace.span[1]
     expect(span.name).to eq 'db.query.redis'
-    expect(span.meta[:commands]).to eq 'GET'
+    expect(span.meta[:commands]).to eq 'GET mykey'
     expect(span.meta[:server]).to eq 'redis://127.0.0.1:16379/0'
   end
 
@@ -49,7 +49,7 @@ RSpec.describe ::Mnemosyne::Probes::Redis::Command, probe: :redis do
 
     span = trace.span[0]
     expect(span.name).to eq 'db.query.redis'
-    expect(span.meta[:commands]).to eq 'SET, SET'
+    expect(span.meta[:commands]).to eq "SET foo ?\nSET baz ?"
     expect(span.meta[:pipelined]).to eq true
     expect(span.meta[:server]).to eq 'redis://127.0.0.1:16379/0'
   end
@@ -67,7 +67,7 @@ RSpec.describe ::Mnemosyne::Probes::Redis::Command, probe: :redis do
 
     span = trace.span[0]
     expect(span.name).to eq 'db.query.redis'
-    expect(span.meta[:commands]).to eq 'SET, SET'
+    expect(span.meta[:commands]).to eq "SET mykey ?\nSET foo ?"
     expect(span.meta[:pipelined]).to eq true
     expect(span.meta[:server]).to eq 'redis://127.0.0.1:16379/0'
   end
@@ -85,7 +85,7 @@ RSpec.describe ::Mnemosyne::Probes::Redis::Command, probe: :redis do
 
     span = trace.span[0]
     expect(span.name).to eq 'db.query.redis'
-    expect(span.meta[:commands]).to eq 'SET, SET'
+    expect(span.meta[:commands]).to eq "SET mykey ?\nSET foo ?"
     expect(span.meta[:pipelined]).to eq true
     expect(span.meta[:server]).to eq 'redis://127.0.0.1:16379/0'
   end
@@ -101,7 +101,7 @@ RSpec.describe ::Mnemosyne::Probes::Redis::Command, probe: :redis do
 
     span = trace.span[0]
     expect(span.name).to eq 'db.query.redis'
-    expect(span.meta[:commands]).to eq 'UNKNOWN_FUNCTION'
+    expect(span.meta[:commands]).to eq 'UNKNOWN_FUNCTION ?'
     expect(span.meta[:error]).to start_with 'ERR unknown command'
     expect(span.meta[:server]).to eq 'redis://127.0.0.1:16379/0'
   end

--- a/spec/mnemosyne/probes/redis/command_spec.rb
+++ b/spec/mnemosyne/probes/redis/command_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/redis'
+
+RSpec.describe ::Mnemosyne::Probes::Redis::Command, probe: :redis do
+  let(:redis) { Redis.new host: '127.0.0.1', port: 16_379 }
+
+  it 'still works without tracing' do
+    redis.set('mykey', 'hello world')
+    result = redis.get('mykey')
+
+    expect(result).to eq 'hello world'
+  end
+
+  it 'creates a span for each command' do
+    trace = with_trace do
+      result1 = redis.set('mykey', 'hello world')
+      result2 = redis.get('mykey')
+
+      expect(result1).to eq 'OK'
+      expect(result2).to eq 'hello world'
+    end
+
+    expect(trace.span.length).to eq 2
+
+    span = trace.span[0]
+    expect(span.name).to eq 'db.query.redis'
+    expect(span.meta[:commands]).to eq 'SET'
+
+    span = trace.span[1]
+    expect(span.name).to eq 'db.query.redis'
+    expect(span.meta[:commands]).to eq 'GET'
+  end
+
+  it 'creates just one span for pipelined (parallel) commands' do
+    trace = with_trace do
+      result = redis.pipelined do
+        redis.set 'foo', 'bar'
+        redis.set 'baz', 'bam'
+      end
+
+      expect(result).to eq %w[OK OK]
+    end
+
+    expect(trace.span.length).to eq 1
+
+    span = trace.span[0]
+    expect(span.name).to eq 'db.query.redis'
+    expect(span.meta[:commands]).to eq 'SET, SET'
+    expect(span.meta[:pipelined]).to eq true
+  end
+
+  it 'traces queued commands (also run in parallel when committing)' do
+    trace = with_trace do
+      redis.queue 'SET', 'mykey', 'hello world'
+      redis.queue 'SET', 'foo', 'bar'
+      result = redis.commit
+
+      expect(result).to eq %w[OK OK]
+    end
+
+    expect(trace.span.length).to eq 1
+
+    span = trace.span[0]
+    expect(span.name).to eq 'db.query.redis'
+    expect(span.meta[:commands]).to eq 'SET, SET'
+    expect(span.meta[:pipelined]).to eq true
+  end
+
+  it 'traces commands queued with array syntax' do
+    trace = with_trace do
+      redis.queue %w[SET mykey hello]
+      redis.queue %w[SET foo bar]
+      result = redis.commit
+
+      expect(result).to eq %w[OK OK]
+    end
+
+    expect(trace.span.length).to eq 1
+
+    span = trace.span[0]
+    expect(span.name).to eq 'db.query.redis'
+    expect(span.meta[:commands]).to eq 'SET, SET'
+    expect(span.meta[:pipelined]).to eq true
+  end
+
+  it 'attaches errors to the span' do
+    trace = with_trace do
+      expect do
+        redis.call 'UNKNOWN_FUNCTION', 'SOME_ARGUMENT'
+      end.to raise_error(Redis::CommandError)
+    end
+
+    expect(trace.span.length).to eq 1
+
+    span = trace.span[0]
+    expect(span.name).to eq 'db.query.redis'
+    expect(span.meta[:commands]).to eq 'UNKNOWN_FUNCTION'
+    expect(span.meta[:error]).to start_with 'ERR unknown command'
+  end
+end

--- a/spec/support/redis.conf
+++ b/spec/support/redis.conf
@@ -1,0 +1,5 @@
+bind 127.0.0.1
+databases 16
+appendonly no
+save ""
+port 16379

--- a/spec/support/redis.rb
+++ b/spec/support/redis.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'redis'
+
+RSpec.configure do |c|
+  c.before(:suite) do
+    redis_pid = fork { exec 'redis-server spec/support/redis.conf' }
+
+    # Wait for the process to have started, otherwise specs may fail
+    sleep 1
+
+    at_exit do
+      Process.kill('USR1', redis_pid)
+    end
+  end
+end


### PR DESCRIPTION
As needed to better inspect / debug Redis commands and behavior in our production services.

Credits to OpenTelemetry (https://github.com/open-telemetry/opentelemetry-ruby), which helped me find a good place for monkey-patching the `redis` gem and notice different ways to call Redis commands.

The tests should nicely explain how Redis commands are turned into spans.