### PR TITLE
Redis: Whitelist more commands (and arguments) for metadata

### DIFF
--- a/lib/mnemosyne/probes/redis/command.rb
+++ b/lib/mnemosyne/probes/redis/command.rb
@@ -63,8 +63,43 @@ module Mnemosyne
             # The value can be a list of safe argument indices, or "*" (all).
             #
             KNOWN_ARGUMENTS = {
+              'BLPOP' => '*',
+              'BRPOP' => '*',
+              'EVALSHA' => [0, 1],
+              'EXISTS' => '*',
+              'EXPIRE' => '*',
               'GET' => '*',
-              'SET' => [0]
+              'HGET' => '*',
+              'HGETALL' => '*',
+              'HMGET' => '*',
+              'HMSET' => [0, 1],
+              'HSCAN' => '*',
+              'INCRBY' => '*',
+              'LLEN' => '*',
+              'LPUSH' => [0],
+              'LRANGE' => '*',
+              'LREM' => [0, 1],
+              'MGET' => '*',
+              'MSET' => [0],
+              'RPUSH' => [0],
+              'RPOP' => '*',
+              'SADD' => [0],
+              'SCARD' => '*',
+              'SCAN' => '*',
+              'SCRIPT LOAD' => [],
+              'SET' => [0],
+              'SREM' => [0],
+              'SSCAN' => '*',
+              'UNLINK' => '*',
+              'ZADD' => [0],
+              'ZCARD' => '*',
+              'ZINCRBY' => [0, 1],
+              'ZRANGE' => '*',
+              'ZRANGEBYSCORE' => '*',
+              'ZREM' => [0],
+              'ZREMRANGEBYSCORE' => '*',
+              'ZREVRANGE' => '*',
+              'ZSCAN' => '*'
             }.freeze
 
             def parse_name_and_args(command)

--- a/lib/mnemosyne/probes/redis/command.rb
+++ b/lib/mnemosyne/probes/redis/command.rb
@@ -60,8 +60,10 @@ module Mnemosyne
             # that should be included verbatim in the metadata. Arguments not
             # listed here will be replaced by a "?" character.
             #
+            # The value can be a list of safe argument indices, or "*" (all).
+            #
             KNOWN_ARGUMENTS = {
-              'GET' => [0],
+              'GET' => '*',
               'SET' => [0]
             }.freeze
 
@@ -72,9 +74,16 @@ module Mnemosyne
               name = command.delete_at(0).to_s.upcase
 
               allowed = KNOWN_ARGUMENTS[name] || []
-              args = command.each_with_index.map do |arg, index|
-                allowed.include?(index) ? arg : '?'
-              end.join(' ')
+              args = case allowed
+                       when '*' # All arguments considered safe
+                         command
+                       when Array # A list of allowed argument indices
+                         command.each_with_index.map do |arg, index|
+                           allowed.include?(index) ? arg : '?'
+                         end
+                       else # Unknown command - assume nothing is safe
+                         Array.new(command.length, '?')
+                     end.join(' ')
 
               [name, args]
             end


### PR DESCRIPTION
Follow-up to #34.

This will give us slightly more useful metadata in Redis spans in our application. I compiled the list of commands to add by grepping the Sidekiq source code. 😉 

I also added the capability to mark all arguments of a command as safe with an asterisk, for use with trivial commands or those with variable lists of arguments that are all safe.