### PR TITLE
fix: Invalid exception class for ActionDispatch::ExceptionWrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Add testing for Rails 7.1 by @MrSerth
 
+### Fixed
+
+- Invalid exception class for ActionDispatch::ExceptionWrapper by @jgraichen
+
 ## [1.16.0] - 2023-08-24
 
 ### Added

--- a/lib/mnemosyne/probes/action_dispatch/show_exceptions.rb
+++ b/lib/mnemosyne/probes/action_dispatch/show_exceptions.rb
@@ -12,7 +12,12 @@ module Mnemosyne
           module Instrumentation
             def render_exception(env, exception)
               if (trace = ::Mnemosyne::Instrumenter.current_trace)
-                trace.attach_error(exception)
+                if exception.respond_to?(:unwrapped_exception) && exception.respond_to?(:exception)
+                  # ActionDispatch::ExceptionWrapper
+                  trace.attach_error(exception.exception)
+                else
+                  trace.attach_error(exception)
+                end
               end
 
               super

--- a/spec/mnemosyne/probes/action_dispatch/show_exceptions_spec.rb
+++ b/spec/mnemosyne/probes/action_dispatch/show_exceptions_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'action_dispatch'
+require 'action_view'
+
+RSpec.describe Mnemosyne::Probes::ActionDispatch::ShowExceptions::Probe, probe: :rails do
+  let(:exception_application) do
+    ->(_env) { [200, {}, ''] }
+  end
+
+  let(:application) do
+    raise_error = -> { raise error }
+    exception_application = self.exception_application
+
+    Rack::Builder.app do
+      use ActionDispatch::ShowExceptions, exception_application
+      run ->(_env) { raise_error.call }
+    end
+  end
+
+  let(:mock) { Rack::MockRequest.new(application) }
+  let(:error) { RuntimeError.new('ABC') }
+
+  it 'attaches an exception' do
+    trace = with_trace do
+      mock.request
+    end
+
+    expect(trace.errors.size).to eq 1
+
+    trace.errors.first.tap do |record|
+      expect(record.error).to be error
+    end
+  end
+end


### PR DESCRIPTION
The action dispatch probe must unpack the newly wrapped exception on Rails 7.1, before attaching it to the trace.